### PR TITLE
Remove URN values from examples.

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -50,4 +50,3 @@ jobs:
         path: |
           draft-*.html
           draft-*.txt
-

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ lib
 *.xml
 tmp*.json
 __pycache__
+*egg-info
+.hypothesis

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -18,7 +18,7 @@ repos:
         args: [--allow-multiple-documents]
     -   id: check-added-large-files
 - repo: https://github.com/myint/autoflake
-  rev: v2.0.0
+  rev: v2.3.1
   hooks:
     - id: autoflake
       args:
@@ -26,11 +26,11 @@ repos:
         - --remove-unused-variables
         - --remove-all-unused-imports
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 25.9.0
     hooks:
     -   id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  rev: 7.0.0
   hooks:
     - id: isort
       name: isort (python)
@@ -44,11 +44,11 @@ repos:
       name: isort (pyi)
       types: [pyi]
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.7.4
+  rev: 1.8.6
   hooks:
     - id: bandit
       name: bandit
@@ -59,6 +59,6 @@ repos:
       language_version: python3
       types: [python]
 - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-  rev: v1.3.1
+  rev: v1.4.2
   hooks:
     - id: python-safety-dependencies-check

--- a/draft-polli-design-process.md
+++ b/draft-polli-design-process.md
@@ -523,9 +523,9 @@ though there is no space in the schema instance to provide a name for the countr
       x-jsonld-context:
         "@vocab": "https://schema.org/"
         nationality:
-          "@type": "@id"
+          "@type": "@vocab"
           "@context":
-            "@base": "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#"
+            "@vocab": "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#"
       type: object
       properties:
         givenName:
@@ -1112,9 +1112,9 @@ Person:
      custom_id: null  # detach this property from the @vocab
      country:
        "@id": addressCountry
-       "@type": "@id"
+       "@type": "@vocab"
        "@context":
-          "@base": "http://publications.europa.eu/resource/authority/country/"
+          "@vocab": "http://publications.europa.eu/resource/authority/country/"
 
   type: object
   required:
@@ -1240,14 +1240,14 @@ BirthPlace:
     "@vocab": "https://w3id.org/italia/onto/CLV/"
     country:
       "@id": "hasCountry"
-      "@type": "@id"
+      "@type": "@vocab"
       "@context":
-        "@base": "http://publications.europa.eu/resource/authority/country/"
+        "@vocab": "http://publications.europa.eu/resource/authority/country/"
     province:
       "@id": "hasProvince"
-      "@type": "@id"
+      "@type": "@vocab"
       "@context":
-        "@base": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
+        "@vocab": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
   type: object
   required:
     - province
@@ -1308,16 +1308,16 @@ The instance context contains information from both
         "city": "hasCity",
         "country": {
           "@id": "hasCountry",
-          "@type": "@id",
+          "@type": "@vocab",
           "@context": {
-            "@base": "http://publications.europa.eu/resource/authority/country/"
+            "@vocab": "http://publications.europa.eu/resource/authority/country/"
           }
         },
         "province": {
           "@id": "hasProvince",
-          "@type": "@id",
+          "@type": "@vocab",
           "@context": {
-            "@base": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
+            "@vocab": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
           }
         }
       }

--- a/draft-polli-design-process.md
+++ b/draft-polli-design-process.md
@@ -290,7 +290,7 @@ The following schema uses a tax code as an identifier.
       x-jsonld-context:
         "@vocab": "https://schema.org/"
         tax_code: "@id"
-        "@base": "urn:example:tax:it:"
+        "@base": "https://example.com/tax/it/"
         given_name: givenName
         family_name: familyName
       type: object
@@ -317,12 +317,14 @@ The following schema uses a tax code as an identifier.
 The associated RDF graph is:
 
 ~~~ text
-urn:example:tax:it:RSSMRO99A04H501A
+@prefix schema: <https://schema.org/> .
+
+<https://example.com/tax/it/RSSMRO99A04H501A>
   a schema:Person ;
   schema:givenName "Mario" ;
   schema:familyName "Rossi" ;
   schema:children
-  urn:example:tax:it:RSSLCC99A04H501A
+  <https://example.com/tax/it/RSSLCC99A04H501A>
 .
 ~~~
 
@@ -368,6 +370,8 @@ The resulting RDF consists in two, linked nodes,
 where the identifier is the `person_id` property.
 
 ~~~ text
+@prefix schema: <https://schema.org/> .
+
 <urn:example:person:1234567890123456>
   a schema:RegisteredResidentPerson ;
   schema:givenName "Mario" ;
@@ -864,7 +868,7 @@ components:
       x-jsonld-context:
         RPO: https://w3id.org/italia/onto/RPO/
         tax_code: '@id'
-        '@base': 'urn:example:tax:it:'
+        '@base': 'https://example.com/tax/it/'
       type: object
       properties:
         tax_code:
@@ -902,7 +906,7 @@ components:
       x-jsonld-context:
         RPO: https://w3id.org/italia/onto/RPO/
         tax_code: '@id'
-        '@base': 'urn:example:tax:it:'
+        '@base': 'https://example.com/tax/it/'
       type: object
       required:
         - tax_code
@@ -1051,7 +1055,6 @@ Person:
      custom_id: null  # detach this property from the @vocab
      country:
        "@id": addressCountry
-       "@language": en
   type: object
   required:
   - given_name
@@ -1076,6 +1079,9 @@ The example object is assembled as a JSON-LD object as follows.
   "@context": {
     "@vocab": "https://schema.org/",
     "custom_id": null
+    "country": {
+      "@id": "addressCountry"
+    }
   },
   "@type": "https://schema.org/Person",
   "familyName": "Doe",
@@ -1207,7 +1213,7 @@ Applying the workflow described in {{interpreting}}
 just recursively copying the x-jsonld-context,
 the instance context could have been more complex.
 
-~~~ json
+~~~ example
 {
   ...
   "@context": {
@@ -1234,6 +1240,23 @@ In the following schema document,
 the "Citizen" schema references the "BirthPlace" schema.
 
 ~~~ yaml
+Citizen:
+  x-jsonld-type: Person
+  x-jsonld-context:
+    "email": "@id"
+    "@vocab": "https://w3.org/ns/person#"
+  type: object
+  properties:
+    email: { type: string }
+    birthplace:
+      $ref: "#/BirthPlace"
+  example:
+    email: "mailto:a@example"
+    givenName: Roberto
+    familyName: Polli
+    birthplace:
+      province: LT
+      country: ITA
 BirthPlace:
   x-jsonld-type: https://w3id.org/italia/onto/CLV/Feature
   x-jsonld-context:
@@ -1262,23 +1285,6 @@ BirthPlace:
   example:
     province: RM
     country: ITA
-Citizen:
-  x-jsonld-type: Person
-  x-jsonld-context:
-    "email": "@id"
-    "@vocab": "https://w3.org/ns/person#"
-  type: object
-  properties:
-    email: { type: string }
-    birthplace:
-      $ref: "#/BirthPlace"
-  example:
-    email: "mailto:a@example"
-    givenName: Roberto
-    familyName: Polli
-    birthplace:
-      province: LT
-      country: ITA
 
 ~~~
 {: title="A schema with object contexts." #ex-object-contexts}
@@ -1294,7 +1300,7 @@ The instance context contains information from both
   "givenName": "Roberto",
   "familyName": "Polli",
   "birthplace": {
-    "province": "RM",
+    "province": "LT",
     "country": "ITA",
     "@type": "https://w3id.org/italia/onto/CLV/Feature"
   },
@@ -1341,8 +1347,8 @@ That can be serialized as `text/turtle` as
   eu:givenName  "Roberto"
 .
 _:b0 rdf:type itl:Feature ;
-  itl:hasCountry <http://publications.europa.eu/resource/authority/country/ITA> .
-  itl:hasProvince <https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/RM>
+  itl:hasCountry <http://publications.europa.eu/resource/authority/country/ITA> ;
+  itl:hasProvince <https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/LT>
 .
 ~~~
 {:title="The above entry in text/turtle" #ex-composite-context-turtle}

--- a/draft-polli-restapi-ld-keywords.md
+++ b/draft-polli-restapi-ld-keywords.md
@@ -603,9 +603,9 @@ Person:
      custom_id: null  # detach this property from the @vocab
      country:
        "@id": addressCountry
-       "@type": "@id"
+       "@type": "@vocab"
        "@context":
-          "@base": "http://publications.europa.eu/resource/authority/country/"
+          "@vocab": "http://publications.europa.eu/resource/authority/country/"
 
   type: object
   required:
@@ -733,14 +733,14 @@ BirthPlace:
     "@vocab": "https://w3id.org/italia/onto/CLV/"
     country:
       "@id": "hasCountry"
-      "@type": "@id"
+      "@type": "@vocab"
       "@context":
-        "@base": "http://publications.europa.eu/resource/authority/country/"
+        "@vocab": "http://publications.europa.eu/resource/authority/country/"
     province:
       "@id": "hasProvince"
-      "@type": "@id"
+      "@type": "@vocab"
       "@context":
-        "@base": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
+        "@vocab": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
   type: object
   required:
     - province
@@ -801,16 +801,16 @@ The instance context contains information from both
         "city": "hasCity",
         "country": {
           "@id": "hasCountry",
-          "@type": "@id",
+          "@type": "@vocab",
           "@context": {
-            "@base": "http://publications.europa.eu/resource/authority/country/"
+            "@vocab": "http://publications.europa.eu/resource/authority/country/"
           }
         },
         "province": {
           "@id": "hasProvince",
-          "@type": "@id",
+          "@type": "@vocab",
           "@context": {
-            "@base": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
+            "@vocab": "https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/"
           }
         }
       }

--- a/draft-polli-restapi-ld-keywords.md
+++ b/draft-polli-restapi-ld-keywords.md
@@ -382,8 +382,8 @@ that Linked Data keywords are JSON Literals.
 
 ~~~ json
 { "@context": {
-    "x-jsonld-context: { "@type": "@json"},
-    "x-jsonld-type: { "@type": "@json"}
+    "x-jsonld-context": { "@type": "@json"},
+    "x-jsonld-type": { "@type": "@json"}
   }
 }
 ~~~
@@ -534,7 +534,7 @@ Person JSON Schema with semantic information
 provided by the x-jsonld-type and x-jsonld-context.
 Type information is provided as a URI reference.
 
-~~~ example
+~~~ yaml
 Person:
   "x-jsonld-type": "https://schema.org/Person"
   "x-jsonld-context":
@@ -542,7 +542,6 @@ Person:
      custom_id: null  # detach this property from the @vocab
      country:
        "@id": addressCountry
-       "@language": en
   type: object
   required:
   - given_name
@@ -567,6 +566,9 @@ The example object is assembled as a JSON-LD object as follows.
   "@context": {
     "@vocab": "https://schema.org/",
     "custom_id": null
+    "country": {
+       "@id": "addressCountry"
+    }
   },
   "@type": "https://schema.org/Person",
   "familyName": "Doe",
@@ -583,7 +585,7 @@ The above JSON-LD can be represented as `text/turtle` as follows.
 @prefix schema: <https://schema.org/>
 
 _:b0 rdf:type schema:Person    ;
-     schema:country     "FRA"  ;
+     schema:addressCountry  "FRA"  ;
      schema:familyName  "Doe"  ;
      schema:givenName   "John" .
 ~~~
@@ -594,11 +596,12 @@ The following example shows a
 "Person" schema with semantic information
 provided by the x-jsonld-type and x-jsonld-context.
 
-~~~ example
+~~~ yaml
 Person:
   "x-jsonld-type": "https://schema.org/Person"
   "x-jsonld-context":
      "@vocab": "https://schema.org/"
+     "@base": "https://example.org/people/"
      email: "@id"
      custom_id: null  # detach this property from the @vocab
      country:
@@ -633,7 +636,8 @@ The resulting RDF graph is
 @prefix schema: <https://schema.org/> .
 @prefix country: <http://publications.europa.eu/resource/authority/country/> .
 
-<mailto:jon@doe.example>
+<https://example.org/people/jon@doe.example>
+  a schema:Person           ;
   schema:familyName "Doe"          ;
   schema:givenName "John"          ;
   schema:addressCountry country:FRA .
@@ -700,7 +704,7 @@ Applying the workflow described in {{interpreting}}
 just recursively copying the x-jsonld-context,
 the instance context could have been more complex.
 
-~~~ json
+~~~ example
 {
   ...
   "@context": {
@@ -727,6 +731,23 @@ In the following schema document,
 the "Citizen" schema references the "BirthPlace" schema.
 
 ~~~ yaml
+Citizen:
+  x-jsonld-type: Person
+  x-jsonld-context:
+    "email": "@id"
+    "@vocab": "https://w3.org/ns/person#"
+  type: object
+  properties:
+    email: { type: string }
+    birthplace:
+      $ref: "#/BirthPlace"
+  example:
+    email: "mailto:a@example"
+    givenName: Roberto
+    familyName: Polli
+    birthplace:
+      province: LT
+      country: ITA
 BirthPlace:
   x-jsonld-type: https://w3id.org/italia/onto/CLV/Feature
   x-jsonld-context:
@@ -755,23 +776,6 @@ BirthPlace:
   example:
     province: RM
     country: ITA
-Citizen:
-  x-jsonld-type: Person
-  x-jsonld-context:
-    "email": "@id"
-    "@vocab": "https://w3.org/ns/person#"
-  type: object
-  properties:
-    email: { type: string }
-    birthplace:
-      $ref: "#/BirthPlace"
-  example:
-    email: "mailto:a@example"
-    givenName: Roberto
-    familyName: Polli
-    birthplace:
-      province: LT
-      country: ITA
 
 ~~~
 {: title="A schema with object contexts." #ex-object-contexts}
@@ -787,7 +791,7 @@ The instance context contains information from both
   "givenName": "Roberto",
   "familyName": "Polli",
   "birthplace": {
-    "province": "RM",
+    "province": "LT",
     "country": "ITA",
     "@type": "https://w3id.org/italia/onto/CLV/Feature"
   },
@@ -834,8 +838,8 @@ That can be serialized as `text/turtle` as
   eu:givenName  "Roberto"
 .
 _:b0 rdf:type itl:Feature ;
-  itl:hasCountry <http://publications.europa.eu/resource/authority/country/ITA> .
-  itl:hasProvince <https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/RM>
+  itl:hasCountry <http://publications.europa.eu/resource/authority/country/ITA> ;
+  itl:hasProvince <https://w3id.org/italia/data/identifiers/provinces-identifiers/vehicle-code/LT>
 .
 ~~~
 {:title="The above entry in text/turtle" #ex-composite-context-turtle}

--- a/draft-polli-restapi-ld-keywords.md
+++ b/draft-polli-restapi-ld-keywords.md
@@ -644,6 +644,16 @@ The resulting RDF graph is
 ~~~
 {: title="An RDF graph with semantic context and type." #ex-rdf-from-json}
 
+Note that in the above example:
+
+- the `email` property is mapped to `@id`,
+  thus making the instance IRI dependent on its value.
+  Since it's not an absolute IRI,
+  the `@base` keyword is used to provide a base IRI
+  i.e. `https://example.org/people/` + `jon@doe.example`;
+- the `country` property is associated with the country
+  vocabulary using the `@type: @vocab` keyword.
+
 ## Cyclic schema {#ex-cyclic-schema}
 
 The following schema contains a cyclic reference.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema==4.6.0
-PyLD==2.0.3
+PyLD==2.0.4
 pytest==7.1.2
 PyYAML
 typing_extensions==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ PyLD==2.0.4
 pytest==7.1.2
 PyYAML
 typing_extensions==4.2.0
+rdflib==7.4.0
+oxrdflib

--- a/tests/section-1.oas3.yaml
+++ b/tests/section-1.oas3.yaml
@@ -45,14 +45,19 @@ components:
       example:
         identifier: ITA
         name: Italy
+      x-rdf: |-
+        @prefix : <https://schema.org/> .
+
+        <https://en.wikipedia.org/wiki/ITA> a :Country ;
+            :name "Italy" .
     Person:
       x-jsonld-type: Person
       x-jsonld-context:
         "@vocab": "https://schema.org/"
         nationality:
-          "@type": "@id"
+          "@type": "@vocab"
           "@context":
-            "@base": "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#"
+            "@vocab": "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#"
       type: object
       properties:
         givenName:
@@ -65,6 +70,13 @@ components:
         givenName: John
         familyName: Doe
         nationality: ITA
+      x-rdf: |-
+        @prefix : <https://schema.org/> .
+
+        [] a :Person ;
+            :familyName "Doe" ;
+            :givenName "John" ;
+            :nationality <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#ITA> .
     NestedPerson:
       x-jsonld-type: Person
       x-jsonld-context:

--- a/tests/section-1.oas3.yaml
+++ b/tests/section-1.oas3.yaml
@@ -35,7 +35,7 @@ components:
       x-jsonld-context:
         "@vocab": "https://schema.org/"
         identifier: "@id"
-        "@base": "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#"
+        "@base": "http://publications.europa.eu/resource/authority/country/"
       type: object
       properties:
         identifier:
@@ -47,17 +47,22 @@ components:
         name: Italy
       x-rdf: |-
         @prefix : <https://schema.org/> .
+        @prefix country: <http://publications.europa.eu/resource/authority/country/> .
 
-        <https://en.wikipedia.org/wiki/ITA> a :Country ;
+        country:ITA a :Country ;
             :name "Italy" .
     Person:
+      description: |-
+        A person where nationality
+        is represented as a country code
+        with @vocab mapping.
       x-jsonld-type: Person
       x-jsonld-context:
         "@vocab": "https://schema.org/"
         nationality:
           "@type": "@vocab"
           "@context":
-            "@vocab": "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#"
+            "@vocab": "http://publications.europa.eu/resource/authority/country/"
       type: object
       properties:
         givenName:
@@ -76,7 +81,7 @@ components:
         [] a :Person ;
             :familyName "Doe" ;
             :givenName "John" ;
-            :nationality <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#ITA> .
+            :nationality <http://publications.europa.eu/resource/authority/country/ITA> .
     NestedPerson:
       x-jsonld-type: Person
       x-jsonld-context:
@@ -95,3 +100,15 @@ components:
         nationality:
           identifier: ITA
           name: Italy
+      x-rdf: |-
+        @prefix : <https://schema.org/> .
+        @prefix country: <http://publications.europa.eu/resource/authority/country/> .
+
+        [] a :Person ;
+            :familyName "Doe" ;
+            :givenName "John" ;
+            :nationality country:ITA .
+
+        country:ITA a :Country ;
+            :name "Italy"
+            .

--- a/tests/test_rdflib.py
+++ b/tests/test_rdflib.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+from rdflib import Graph
+
+
+@pytest.mark.skip("Bug in rdflib")
+def test_mailto_scheme_should_work_jsonld():
+    l = {
+        "@context": {
+            "@vocab": "https://schema.org/",
+            "email": "@id",
+            "@base": "mailto:",
+        },
+        "@type": "https://schema.org/Person",
+        "familyName": "Doe",
+        "email": "a@b.c",
+    }
+    g = Graph()
+    g.parse(data=json.dumps(l), format="application/ld+json")
+    assert list(g)
+    ttl = g.serialize(format="text/turtle")
+    assert ttl.strip()
+
+
+@pytest.mark.skip("Bug in rdflib")
+def test_mailto_scheme_should_work_n3():
+    ttl = """
+@prefix schema: <https://schema.org/> .
+@base <mailto:> .
+
+<a@b.c> a schema:Person ;
+    schema:familyName "Doe" .
+"""
+    g = Graph()
+    g.parse(data=ttl, format="text/turtle")
+    assert list(g)
+    jsonld = g.serialize(format="application/ld+json")
+    assert jsonld.strip()

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,292 @@
+import json
+import re
+from pathlib import Path
+
+import pyld
+import pytest
+import rdflib
+import rdflib.compare
+import yaml
+from rdflib import Graph
+
+from oasld import Instance, RefResolver
+
+DATADIR = Path(__file__).parent
+
+testfiles = [yaml.safe_load(x.read_text()) for x in DATADIR.glob("*.oas3.yaml")]
+testschemas = [
+    (schema_name, schema_content)
+    for f in testfiles
+    for schema_name, schema_content in f["components"]["schemas"].items()
+]
+
+
+def extract_snippets(body: str):
+    pattern = re.compile(
+        r"""
+\n
+~~~ (?P<language>.*?)\n                # Opening example fence
+(?P<content>.*?)                 # Capture the content
+\n
+~~~                             # Closing fence
+\n
+        """,
+        re.VERBOSE | re.DOTALL,
+    )
+    for match in pattern.finditer(body):
+        groups = match.groupdict()
+        language = groups["language"].strip()
+        content = groups["content"]
+
+        if language == "text":
+            yield language.strip(), content
+            continue
+
+        if language not in (
+            "yaml",
+            "json",
+        ):
+            continue
+
+        data = content.replace("...", "")
+        try:
+            data = yaml.safe_load(data)
+        except yaml.YAMLError:
+            continue
+
+        if not isinstance(data, dict):
+            continue
+
+        if "@context" in data:
+            yield "jsonld", content
+            continue
+
+        schema_name, schema_content = next(iter(data.items()))
+        if "example" not in schema_content:
+            continue
+        yield "schema", content
+
+
+@pytest.mark.skip("Incomplete test")
+def test_ld_1():
+    schema_1 = yaml.safe_load((DATADIR / "schema-1.yaml").read_text())
+    resolver = RefResolver(schema_1)
+    schema_name = "PersonaAnagraficamenteResidente"
+
+    schema = schema_1["components"]["schemas"][schema_name]
+    instance_data = schema["example"]
+    instance = Instance(instance_data, schema)
+    instance.process_instance(resolver=resolver)
+
+    result = instance.ld
+    g = Graph()
+    g.parse(data=json.dumps(result), format="application/ld+json")
+    ttl = g.serialize(format="text/turtle")
+
+    raise NotImplementedError
+
+
+@pytest.mark.parametrize("schema_name, schema_content", testschemas)
+def test_ld_schemas(schema_name, schema_content):
+    if not (expected := schema_content.get("x-rdf")):
+        raise pytest.skip("No expected status  in schema")
+
+    if not (i := schema_content["example"]):
+        raise pytest.skip("Empty example in schema")
+
+    if not (c := schema_content.get("x-jsonld-context")):
+        raise pytest.skip("No context directive in schema")
+
+    t = (
+        {"@type": schema_content.get("x-jsonld-type")}
+        if schema_content.get("x-jsonld-type")
+        else {}
+    )
+    l = {"@context": c, **i, **t}
+
+    g = Graph()
+    g.parse(data=json.dumps(l), format="application/ld+json")
+    ttl = g.serialize(format="text/n3")
+    assert (
+        ttl.strip() == expected.strip()
+    ), f"Schema {schema_name} did not match expected RDF output"
+
+
+def parse_spec_md(mdfile: Path):
+    content = mdfile.read_text()
+    content = content.split("--- middle")[1]
+    pattern = re.compile(
+        r"""
+\n                             # a newline
+(?P<header>\#+)              # Capture the header hashes
+\s                             # a space
+(?P<title>.+?)                 # Capture the title
+(?P<identifier>\s\{\#.*?\})?   # Optionally capture the identifier
+\n                             # a newline
+(?P<body>.*?)                   # Capture the body
+(?=\n\#|\Z)                    # Positive lookahead for next header or end of string
+        """,
+        re.VERBOSE | re.DOTALL,
+    )
+    doc = {}
+    for match in pattern.finditer(content):
+        groups = match.groupdict()
+        header = groups["header"]
+        # title = groups["title"]
+        identifier = (
+            groups["identifier"].strip()
+            if groups["identifier"]
+            else groups["title"].strip().replace(" ", "-").lower()
+        )
+        body = groups["body"].strip()
+        level = len(header)
+        assert identifier
+
+        doc[identifier] = {
+            "level": level,
+            "body": body,
+            "examples": [
+                {"language": language, "content": example.strip()}
+                for language, example in extract_snippets(body)
+            ],
+        }
+    return doc
+
+
+def test_parse_md():
+    mdfile = DATADIR.parent / "draft-polli-restapi-ld-keywords.md"
+    doc = parse_spec_md(mdfile)
+    testcases = extract_testcases(doc)
+    return testcases
+
+
+def extract_testcases(doc: dict):
+    testcases = {}
+    for section, data in doc.items():
+        examples = data["examples"]
+        for example in examples:
+            test_id = testcases[section] = testcases.get(section, {})
+            if example["language"] in ("schema", "jsonld"):
+                if "..." in example["content"]:
+                    pass
+                else:
+                    example["language"]
+
+                text = example["content"].replace("...", "")
+                try:
+                    parsed = yaml.safe_load(text)
+                except yaml.YAMLError:
+                    parsed = text
+                d = {
+                    example["language"]: parsed,
+                }
+            elif example["language"] == "text":
+                g = Graph()
+                g.parse(data=example["content"], format="text/turtle")
+                d = {
+                    "rdf": example["content"],
+                    "jld": yaml.safe_load(g.serialize(format="application/ld+json")),
+                }
+            else:
+                continue
+            test_id.update(d)
+    return testcases
+
+
+@pytest.mark.parametrize(
+    "section, schema, jsonld, rdf",
+    [
+        [k, v.get("schema"), v.get("jsonld"), v.get("rdf")]
+        for k, v in test_parse_md().items()
+    ],
+)
+def test_draft_examples_are_correct(section, schema, jsonld, rdf):
+    if not schema:
+        raise pytest.skip("No schema in test case")
+
+    if not any([jsonld, rdf]):
+        raise pytest.skip("No expected output in test case")
+
+    schema_name, schema_content = next(iter(schema.items()))
+    instance = schema_content["example"]
+    context = schema_content.get("x-jsonld-context", {})
+    if not context:
+        raise pytest.skip("No context in schema")
+    l = {
+        **instance,
+        "@context": context,
+    }
+    type_info = schema_content.get("x-jsonld-type")
+    if type_info:
+        l["@type"] = type_info
+
+    i = Instance(instance, schema_content)
+    i.process_instance(resolver=RefResolver(schema))
+
+    result = i.ld
+
+    g_instance = Graph()
+    g_instance.parse(data=json.dumps(result), format="application/ld+json")
+
+    assert (
+        len(g_instance) > 0
+    ), f"Test case {section} produced empty graph: \n{yaml.safe_dump(l)}"
+    g_result = Graph()
+    if rdf:
+        g_result.parse(data=rdf, format="text/turtle")
+    elif jsonld:
+        expanded = pyld.jsonld.expand(jsonld)
+        g_result.parse(data=json.dumps(expanded), format="application/ld+json")
+    else:
+        raise NotImplementedError("No expected output provided")
+
+    assert_isomorphic(g_instance, g_result)
+
+
+def assert_isomorphic(g1: Graph, g2: Graph):
+    i1 = rdflib.compare.to_isomorphic(g1)
+    i2 = rdflib.compare.to_isomorphic(g2)
+    in_both, in_g1, in_g2 = rdflib.compare.graph_diff(i1, i2)
+    dump_nt_sorted = lambda g: "\n".join(sorted(g.serialize(format="nt").splitlines()))
+    assert (
+        i1 == i2
+    ), f"Graphs are not isomorphic {yaml.safe_dump(dict(
+        in_both=dump_nt_sorted(in_both),
+        in_g1=dump_nt_sorted(in_g1),
+        in_g2=dump_nt_sorted(in_g2),
+    ))}"
+
+
+@pytest.mark.skip("Bug in rdflib")
+def test_mailto():
+    l = {
+        "@context": {
+            "@vocab": "https://schema.org/",
+            "email": "@id",
+            "@base": "mailto:/",
+        },
+        "@type": "https://schema.org/Person",
+        "familyName": "Doe",
+        "email": "a@b.c",
+    }
+    g = Graph(store="Oxigraph")
+    g.parse(data=json.dumps(l), format="application/ld+json")
+    assert list(g)
+    ttl = g.serialize(format="text/turtle")
+    assert ttl.strip()
+
+
+@pytest.mark.skip("Bug in rdflib")
+def test_mailto_rdf():
+    ttl = """
+@prefix schema: <https://schema.org/> .
+@base <mailto:> .
+
+<a@b.c> a schema:Person ;
+    schema:familyName "Doe" .
+"""
+    g = Graph()
+    g.parse(data=ttl, format="text/turtle")
+    assert list(g)
+    jsonld = g.serialize(format="application/ld+json")
+    assert jsonld.strip()

--- a/tests/text-based-entries.oas3.yaml
+++ b/tests/text-based-entries.oas3.yaml
@@ -54,7 +54,7 @@ components:
       x-jsonld-context:
         "@vocab": "https://schema.org/"
         tax_code: "@id"
-        "@base": "urn:example:tax:it:"
+        "@base": "urn:example:tax:it/"
         given_name: givenName
         family_name: familyName
       type: object
@@ -76,13 +76,14 @@ components:
         tax_code: RSSMRO99A04H501A
         children:
         - tax_code: RSSLCC99A04H501A
-      x-rdf: >-
-        urn:example:tax:it:RSSMRO99A04H501A a schema:Person ;
-             schema:givenName "Mario" ;
-             schema:familyName "Rossi" ;
-             schema:children
-             urn:example:tax:it:RSSLCC99A04H501A
-        .
+      x-rdf: |-
+        @prefix : <https://schema.org/> .
+
+        <urn:example:tax:it/RSSMRO99A04H501A> a :Person ;
+            :children <urn:example:tax:it/RSSLCC99A04H501A> ;
+            :familyName "Rossi" ;
+            :givenName "Mario" .
+
     RegistryStringL:
       type: string
       maxLength: 64
@@ -106,7 +107,7 @@ components:
       x-jsonld-type: RegisteredResidentPerson
       x-jsonld-context:
         "@vocab": "https://schema.org/"
-        "@base": "urn:example:anpr.it:"
+        "@base": "urn:example:person/"
         person_id: "@id"
         tax_code: taxCode
         given_name: givenName
@@ -132,17 +133,17 @@ components:
         children:
         - person_id: "2234567890123457"
           tax_code: RSSLCC99A04H501A
-      x-rdf: >-
-        <urn:example:person:1234567890123456> a schema:RegisteredResidentPerson ;
-             schema:givenName "Mario" ;
-             schema:familyName "Rossi" ;
-             schema:taxCode "RSSMRO99A04H501A" ;
-             schema:children
-             <urn:example:person:2234567890123457>
-        .
-        <urn:example:person:2234567890123457> a schema:RegisteredResidentPerson ;
-             schema:taxCode "RSSLCC99A04H501A"
-        .
+      x-rdf: |-
+        @prefix : <https://schema.org/> .
+
+        <urn:example:person/1234567890123456> a :RegisteredResidentPerson ;
+            :children <urn:example:person/2234567890123457> ;
+            :familyName "Rossi" ;
+            :givenName "Mario" ;
+            :taxCode "RSSMRO99A04H501A" .
+
+        <urn:example:person/2234567890123457> :taxCode "RSSLCC99A04H501A" .
+
 #
 # If this is a schema-only file, you can leave the following sections empty.
 # Do not remove them, as they are required by the OpenAPI 3.0 specification.

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist = py3, safety
 skipsdist=True
 
 [testenv]
-# deps =
-#   -rrequirements.txt
-#   -rrequirements-dev.txt
+deps =
+  -rrequirements.txt
+  -rrequirements-dev.txt
 #
 # Uncomment here to set an extra PIP_INDEX_URL
 # setenv =
@@ -19,17 +19,6 @@ setenv =
 commands =
   pytest {posargs}
 
-[testenv:safety]
-deps =
-  -rrequirements.txt
-  -rrequirements-dev.txt
-  safety
-
-setenv =
-  PYTHONPATH=:.:
-
-commands =
-  safety check --short-report -r requirements.txt
 
 [flake8]
 # Ignore long lines in flake8 because


### PR DESCRIPTION
## This PR

- [x] fix URN values to end with '/', otherwise the base URI expansion only preserve the scheme
- [x] bump hooks
- [x] Use `"@type": "@vocab"` to support fragment-based vocabularies
- [x] Add preliminary tests
- [x] Test all examples in docs.    